### PR TITLE
Update search URL to use "Latest" instead of "Top"

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -36,7 +36,7 @@ def scrape(screen_name, since_date, until_date, include_retweets=True, wait_secs
     driver = webdriver.Chrome()
     try:
         driver.implicitly_wait(wait_secs)
-        url = "https://twitter.com/search?q=from:{}+since:{}+until:{}".format(screen_name, since_date.isoformat(),
+        url = "https://twitter.com/search?f=tweets&vertical=default&q=from:{}+since:{}+until:{}&src=typd".format(screen_name, since_date.isoformat(),
                                                                               until_date.isoformat())
         if include_retweets:
             url += "+include:retweets"


### PR DESCRIPTION
More tweets show up with "Latest" https://twitter.com/search?f=tweets&q=from%3Agodtributes%20since%3A2017-02-10%20until%3A2017-02-22&src=typd as opposed to "Top" https://twitter.com/search?q=from%3Agodtributes%20since%3A2017-02-10%20until%3A2017-02-22&src=typd

Unfortunately i don't have a crawled set of IDs on hand that shows this difference - but it's mostly replies that show up under "Latest" that are sometimes missing in "Top"